### PR TITLE
feat(table buttons): Now exists buttons to jump between table views on Cocktail List and delail pages

### DIFF
--- a/src/app/components/button/ActionButton.tsx
+++ b/src/app/components/button/ActionButton.tsx
@@ -3,7 +3,7 @@
 type Props = {
   onClick: () => void;
   label: string;
-  variant?: "save" | "remove" | "expand";
+  variant?: "save" | "remove" | "expand" | "double";
   disabled?: boolean;
 };
 
@@ -13,13 +13,16 @@ export default function ActionButton({
   variant = "save",
   disabled = false,
 }: Props) {
-  const baseClasses =
-    "text-white rounded w-min disabled:bg-gray-400 hover:opacity-90 cursor-pointer";
+  const baseClasses = "  hover:opacity-90 cursor-pointer";
 
   const variantClasses = {
-    remove: "px-3 py-2 bg-red-800 hover:bg-red-900",
-    save: "px-3 py-2 bg-gray-700 hover:bg-gray-800",
-    expand: "px-1 py-1 bg-gray-700 hover:bg-gray-800 text-xs",
+    remove:
+      "disabled:bg-gray-400 text-white rounded w-min px-3 py-2 bg-red-800 hover:bg-red-900",
+    save: "disabled:bg-gray-400 text-white rounded w-min px-3 py-2 bg-gray-700 hover:bg-gray-800",
+    expand:
+      "disabled:bg-gray-400 text-white rounded w-min px-1 py-1 bg-gray-700 hover:bg-gray-800 text-xs",
+    double:
+      " disabled:bg-gray-200 rounded w-full px-2 text-2xl font-semibold hover:bg-gray-100 bg-transparent ",
   };
 
   return (

--- a/src/app/layouts/doubleSectionLayout.tsx
+++ b/src/app/layouts/doubleSectionLayout.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import BaseLayout from "./baseLayout";
-import { Sidebar, VizBar, TableData } from "../components";
+import { ActionButton, TableData } from "../components";
 
 type Props = {
   title: string;
@@ -19,6 +19,8 @@ export default function DoubleSectionLayout({
   extraFlag = "",
   id = "",
 }: Props) {
+  const [selectedButton, setSelectedButton] = useState(true);
+
   let children2 = <div></div>;
   switch (typeOf2) {
     case "ingredientDetail":
@@ -48,12 +50,24 @@ export default function DoubleSectionLayout({
     case "cocktailDetail":
       children2 = (
         <section className="flex-1 p-9 bg-white text-black flex flex-col w-full h-screen ">
-          <h2 className="text-2xl font-semibold pb-4">
-            {true
-              ? "Cognitive Production Table"
-              : "Ingredients Cognitive Tables"}
-          </h2>
-          {true ? <TableData type={1} /> : <TableData type={4} />}
+          <div className={` ${selectedButton ? "pb-4" : "pb-2"}`}>
+            <div className="border-b-2 border-gray-500 flex justify-center w-full">
+              <ActionButton
+                onClick={() => setSelectedButton(true)}
+                label="Cocktail View"
+                variant="double"
+                disabled={selectedButton}
+              />
+              <ActionButton
+                onClick={() => setSelectedButton(false)}
+                label="Ingredients View"
+                variant="double"
+                disabled={!selectedButton}
+              />
+            </div>
+          </div>
+
+          {selectedButton ? <TableData type={1} /> : <TableData type={4} />}
         </section>
       );
       break;
@@ -61,12 +75,24 @@ export default function DoubleSectionLayout({
     case "cocktailList":
       children2 = (
         <section className="flex-1 p-9 bg-white text-black flex flex-col w-full h-screen ">
-          <h2 className="text-2xl font-semibold pb-4">
-            {false
-              ? "Cognitive Production Table"
-              : "Ingredients Cognitive Tables"}
-          </h2>
-          {false ? (
+          <div className={` ${selectedButton ? "pb-4" : "pb-2"}`}>
+            <div className="border-b-2 border-gray-500 flex justify-center w-full">
+              <ActionButton
+                onClick={() => setSelectedButton(true)}
+                label="Cocktail View"
+                variant="double"
+                disabled={selectedButton}
+              />
+              <ActionButton
+                onClick={() => setSelectedButton(false)}
+                label="Ingredients View"
+                variant="double"
+                disabled={!selectedButton}
+              />
+            </div>
+          </div>
+
+          {selectedButton ? (
             <TableData type={3} selectedId={id} />
           ) : (
             <TableData type={5} selectedId={id} />


### PR DESCRIPTION
Detail page with VizBar open:
<img width="565" height="64" alt="image" src="https://github.com/user-attachments/assets/7c740c9f-bbf0-48dd-8620-77a15f42f2cf" />

List Page:
<img width="807" height="94" alt="image" src="https://github.com/user-attachments/assets/9f5670e1-18a9-414b-a8f1-fb37bd4fdc23" />
